### PR TITLE
Add Cargo.toml files to crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     "asyncmemo",
+    # depends on failure_ext
+    # "bookmarks",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ members = [
     # "hooks",
     # "mercurial-types",
     # "mercurial",
+    # "metaconfig",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     # "blobstore",
     # "bookmarks",
     # "bundle2-resolver",
+    # "bonsai-utils",
     "bytes-ext",
     # depends on failure_ext
     # "changesets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ members = [
     # "mononoke-types",
     # "repoinfo",
     # "revset",
+    # "server",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     # depends on failure_ext
     # "bookmarks",
     # "bundle2-resolver",
+    "bytes-ext",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,7 @@ members = [
     # "repoinfo",
     # "revset",
     # "server",
+    # depends on netstring crate internal at fb
+    # "sshrelay",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ members = [
     # "mercurial",
     # "metaconfig",
     # "mononoke-types",
+    # "repoinfo",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "asyncmemo",
     # depends on failure_ext
+    # "blobrepo",
     # "bookmarks",
     # "bundle2-resolver",
     "bytes-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "asyncmemo",
     # depends on failure_ext
     # "bookmarks",
+    # "bundle2-resolver",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "bytes-ext",
     # depends on failure_ext
     # "changesets",
+    # "common/pylz4",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ members = [
     # "hgproto",
     # "hooks",
     # "mercurial-types",
+    # "mercurial",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     # build error related to tokio_io::AsyncWrite
     # "async-compression",
+    # "mercurial-bundles",
     "asyncmemo",
     # depends on failure_ext
     # "blobrepo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ members = [
     # "mercurial-types",
     # "mercurial",
     # "metaconfig",
+    # "mononoke-types",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     # "bookmarks",
     # "bundle2-resolver",
     "bytes-ext",
+    # depends on failure_ext
+    # "changesets",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    # build error related to tokio_io::AsyncWrite
+    # "async-compression",
     "asyncmemo",
     # depends on failure_ext
     # "blobrepo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     # "revset",
     # "server",
     # "storage/filekv",
+    # "vfs",
     # depends on netstring crate internal at fb
     # "sshrelay",
     "storage/types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ members = [
     # "hgcli",
     # "hgproto",
     # "hooks",
+    # "mercurial-types",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    # actix_web depends on httparse which uses nightly features
+    # "apiserver",
     # build error related to tokio_io::AsyncWrite
     # "async-compression",
     # "mercurial-bundles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ members = [
     # depends on failure_ext
     # "hgcli",
     # "hgproto",
+    # "hooks",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "asyncmemo",
+    "futures-ext",
+    "storage/types",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ members = [
     "futures-ext",
     # depends on failure_ext
     # "hgcli",
+    # "hgproto",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     # "changesets",
     # "common/pylz4",
     # "eden_server",
+    # "filenodes",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ members = [
     # "metaconfig",
     # "mononoke-types",
     # "repoinfo",
+    # "revset",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     # "repoinfo",
     # "revset",
     # "server",
+    # "storage/filekv",
     # depends on netstring crate internal at fb
     # "sshrelay",
     "storage/types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "asyncmemo",
     # depends on failure_ext
     # "blobrepo",
+    # "blobstore",
     # "bookmarks",
     # "bundle2-resolver",
     "bytes-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     # depends on failure_ext
     # "changesets",
     # "common/pylz4",
+    # "eden_server",
     "futures-ext",
     "storage/types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ members = [
     # "eden_server",
     # "filenodes",
     "futures-ext",
+    # depends on failure_ext
+    # "hgcli",
     "storage/types",
 ]

--- a/apiserver/Cargo.toml
+++ b/apiserver/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "apiserver"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+actix = "0.6.1"
+actix-web = "0.6.14"
+bytes = "0.4.5"
+clap = "2.27.1"
+
+blobrepo = { path = "../blobrepo" }
+bookmarks = { path = "../bookmarks" }

--- a/async-compression/Cargo.toml
+++ b/async-compression/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "async-compression"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.8"
+bzip2 = "0.3.2"
+flate2 = "1.0.1"
+futures = "0.1.17"
+tokio-io = "0.1.4"
+zstd = "0.4.18"

--- a/asyncmemo/Cargo.toml
+++ b/asyncmemo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "asyncmemo"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.5"
+futures = "0.1.17"
+heapsize = "0.4.2"
+linked-hash-map = "0.5.1"
+parking_lot = "0.6.1"
+
+futures-ext = { path = "../futures-ext" }

--- a/blobrepo/Cargo.toml
+++ b/blobrepo/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "blobrepo"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bincode = "1.0.0"
+bytes = "0.4.8"
+error-chain = "0.11.0"
+futures = "0.1.17"
+heapsize = "0.4.2"
+heapsize_derive = "0.1.4"
+serde = "1.0.66"
+serde_derive = "1.0.66"
+tokio-core = "0.1.17"

--- a/blobstore/Cargo.toml
+++ b/blobstore/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "blobstore"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+futures = "0.1.17"
+tokio-core = "0.1.17"
+
+asyncmemo = { path = "../asyncmemo" }

--- a/bonsai-utils/Cargo.toml
+++ b/bonsai-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bonsai-utils"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+futures = "0.1.17"
+itertools = "0.7.2"
+
+futures-ext = { path = "../futures-ext" }
+mercurial-types = { path = "../mercurial-types" }
+mononoke-types = { path = "../mononoke-types" }

--- a/bookmarks/Cargo.toml
+++ b/bookmarks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bookmarks"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+futures = "0.1.17"
+serde_derive = "1.0.66"
+serde = "1.0.66"
+
+futures-ext = { path = "../futures-ext" }
+storage-types = { path = "../storage/types" }

--- a/bundle2-resolver/Cargo.toml
+++ b/bundle2-resolver/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bundle2-resolver"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+bytes = "0.4.5"
+futures = "0.1.17"
+
+futures-ext = { path = "../futures-ext" }

--- a/changesets/Cargo.toml
+++ b/changesets/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "changesets"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+diesel = "1.3.2"
+
+asyncmemo = { path = "../asyncmemo" }

--- a/common/pylz4/Cargo.toml
+++ b/common/pylz4/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "pylz4"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+

--- a/eden_server/Cargo.toml
+++ b/eden_server/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "eden-server"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+
+blobrepo = { path = "../blobrepo" }

--- a/filenodes/Cargo.toml
+++ b/filenodes/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "filenodes"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+
+asyncmemo = { path = "../asyncmemo" }

--- a/futures-ext/Cargo.toml
+++ b/futures-ext/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "futures-ext"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.8"
+futures = "0.1.17"
+tokio-core = "0.1.17"
+tokio-io = "0.1.7"
+tokio = "0.1.7"

--- a/futures-ext/Cargo.toml
+++ b/futures-ext/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPLv2+"
 
 [dependencies]
 bytes = "0.4.8"
+failure = "0.1.1"
 futures = "0.1.17"
 tokio-core = "0.1.17"
 tokio-io = "0.1.7"

--- a/hgcli/Cargo.toml
+++ b/hgcli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "hgcli"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.5"
+clap = "2.27.1"
+error-chain = "0.11.0"
+futures = "0.1.17"
+mio = "0.6.11"
+nix = "0.9.0"
+tokio-core = "0.1.10"
+tokio-io = "0.1.4"
+tokio-proto = "0.1.1"
+tokio-service = "0.1.0"
+tokio-uds = "0.1.7"
+
+futures-ext = { path = "../futures-ext" }

--- a/hgproto/Cargo.toml
+++ b/hgproto/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "hgproto"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.5"
+error-chain = "0.11.0"
+futures = "0.1.17"
+nom = "3.2.1"
+slog = "2.0.12"
+tokio-io = "0.1.4"
+tokio-proto = "0.1.1"
+
+futures-ext = { path = "../futures-ext" }

--- a/hooks/Cargo.toml
+++ b/hooks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hooks"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+error-chain = "0.11.0"
+futures = "0.1.17"
+hlua = "0.4.1"
+maplit = "1.0.0"
+
+blobrepo = { path = "../blobrepo" }

--- a/mercurial-bundles/Cargo.toml
+++ b/mercurial-bundles/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mercurial-bundles"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+byteorder = "1.1.0"
+bytes = "0.4.5"
+error-chain = "0.11.0"
+futures = "0.1.17"
+lazy_static = "0.2.10"
+slog = "2.0.12"
+tokio-io = "0.1.4"
+tokio-proto = "0.1.1"
+url = "1.6.0"
+
+async-compression = { path = "../async-compression" }

--- a/mercurial-types/Cargo.toml
+++ b/mercurial-types/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mercurial-types"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+bincode = "0.9.2"
+bytes = "0.4.5"
+diesel = "1.3.2"
+error-chain = "0.11.0"
+futures = "0.1.17"
+heapsize = "0.4.1"
+heapsize_derive = "0.1.4"
+itertools = "0.7.2"
+lazy_static = "0.2.10"
+quickcheck = "0.4.1"
+rand = "0.3.18"
+rust-crypto = "0.2.36"
+url = "1.6.0"
+serde_derive = "1.0.20"
+serde = "1.0.20"
+
+asyncmemo = { path = "../asyncmemo" }

--- a/mercurial/Cargo.toml
+++ b/mercurial/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mercurial"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+error-chain = "0.11.0"
+futures = "0.1.17"
+itertools = "0.7.2"
+lz4 = "1.22.0"
+memmap = "0.6.1"
+nom = "3.2.1"
+time = "0.1.38"
+
+asyncmemo = { path = "../asyncmemo" }
+bookmarks = { path = "../bookmarks" }
+futures-ext = { path = "../futures-ext" }
+mercurial-types = { path = "../mercurial-types" }
+storage-types = { path = "../storage/types" }

--- a/metaconfig/Cargo.toml
+++ b/metaconfig/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "metaconfig"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+error-chain = "0.11.0"
+futures = "0.1.17"
+
+mercurial = { path = "../mercurial" }

--- a/mononoke-types/Cargo.toml
+++ b/mononoke-types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mononoke-types"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+ascii = "0.8.6"
+bincode = "0.9.2"
+blake2 = "0.7.1"
+bytes = "0.4.5"
+chrono = "0.4.4"
+
+asyncmemo = { path = "../asyncmemo" }

--- a/repoinfo/Cargo.toml
+++ b/repoinfo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "repoinfo"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+futures = "0.1.17"
+heapsize = "0.4.1"
+heapsize_derive = "0.1.4"
+
+asyncmemo = { path = "../asyncmemo" }
+futures-ext = { path = "../futures-ext" }
+mercurial-types = { path = "../mercurial-types" }

--- a/revset/Cargo.toml
+++ b/revset/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "revset"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+error-chain = "0.11.0"
+futures = "0.1.17"
+maplit = "1.0.0"
+
+asyncmemo = { path = "../asyncmemo" }
+mercurial-types = { path = "../mercurial-types" }
+repoinfo = { path = "../repoinfo" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "server"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+clap = "2.27.1"
+error-chain = "0.11.0"
+futures = "0.1.17"
+slog = "2.0.12"
+tokio-core = "0.1.10"
+tokio-io = "0.1.4"
+tokio-uds = "0.1.7"
+
+bookmarks = {path = "../bookmarks" }
+futures-ext = { path = "../futures-ext" }

--- a/sshrelay/Cargo.toml
+++ b/sshrelay/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sshrelay"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bytes = "0.4.5"
+serde = "1.0.20"
+serde_derive = "1.0.20"
+serde_json = "1.0.21"
+tokio-io = "0.1.4"

--- a/storage/filekv/Cargo.toml
+++ b/storage/filekv/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "filekv"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+bincode = "1.0.0"
+error-chain = "0.11.0"
+futures = "0.1.17"
+futures-cpupool = "0.1.8"
+nix = "0.11.0"
+rand = "0.5.1"
+serde = "1.0.66"
+
+futures-ext = { path = "../../futures-ext" }
+storage-types = { path = "../types" }

--- a/storage/types/Cargo.toml
+++ b/storage/types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "storage-types"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+rand = "0.5.1"
+serde = "1.0.66"
+serde_derive = "1.0.66"

--- a/vfs/Cargo.toml
+++ b/vfs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vfs"
+version = "0.0.1"
+authors = ["Facebook"]
+license = "GPLv2+"
+
+[dependencies]
+error-chain = "0.11.0"
+futures = "0.1.17"
+itertools = "0.7.2"
+
+mercurial-types = { path = "../mercurial-types" }


### PR DESCRIPTION
This is a series of patches which adds Cargo.toml files to all the crates and tries to build them. There is individual patch for each crate which tells whether that crate build successfully right now using cargo or not, and if not, reason behind that.

Following are the reasons why the crates don't build:

  * failure_ext and netstring crates which are internal
  * error related to tokio_io, there might be an patched version of tokio_io internally
  * actix-web depends on httparse which uses nightly features

All the build is done using rustc version `rustc 1.27.0-dev`.