### PR TITLE
mononoke/common: Remove intermediate computation

### DIFF
--- a/common/topo_sort/src/lib.rs
+++ b/common/topo_sort/src/lib.rs
@@ -7,9 +7,8 @@
 #![deny(warnings)]
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     hash::Hash,
-    iter,
 };
 
 /// Sort nodes of DAG topologically. Implemented as depth-first search with tail-call
@@ -32,11 +31,7 @@ where
     let mut marks = HashMap::new();
     let mut stack = Vec::new();
     let mut output = Vec::new();
-    for node in dag
-        .iter()
-        .flat_map(|(n, ns)| iter::once(n).chain(ns))
-        .collect::<HashSet<_>>()
-    {
+    for (node, _) in dag {
         stack.push(Action::Visit(node));
         while let Some(action) = stack.pop() {
             match action {


### PR DESCRIPTION
Remove computing a HashSet which has the effect of adding
parents that are not keys in the dag hash to the list of
nodes to be processed. Non-key parents are already being
processed.

The commit should be a functional NOP.

Aside:
1. What are called parents in other files are called children here.
2. The commit which created this file moved this function
unchanged from blobrepo/src/utils.rs . Please review this commit
carefully as it is replacing not something new, but something
that has been around. Of course, review carefully anyway!
I could be missing something.
3. Not clear why a topological sort would include non-key items,
since there isn't enough information to topo-sort non-key items
correctly.
One of the users
(blobrepo/src/repo.rs::get_hg_from_bonsai_changeset_with_impl)
filters out the non-key parents, and the other two users
(blobrepo/src/repo.rs::save_bonsai_changesets and
derived_data/src/derive_impl.rs::derive_impl) aren't as clear
about either having no non-key parents in HashMap, or are filtering
them out somewhere, or are using them. If non-key parents exist,
are later processed, and order matters, then that could potentially
cause a problem.

Additional note not in commit comment: cool algorithm.
I've not seen topo-sort code before. Fun to read through!